### PR TITLE
Use ~ in favor of @ for internal modules

### DIFF
--- a/server/src/app.spec.ts
+++ b/server/src/app.spec.ts
@@ -1,5 +1,5 @@
-import { logger } from '@shared/helpers/logger';
-import { wait } from '@test/helpers/wait';
+import { logger } from '~shared/helpers/logger';
+import { wait } from '~test/helpers/wait';
 
 import { App } from './app';
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,17 +2,17 @@ import { AddressInfo } from 'net';
 import { default as express, Application } from 'express';
 import { Server } from 'http';
 
-import { default as config } from '@config';
-import { ErrorMiddleware } from '@core/middleware/error';
-import { GlobalMiddleware } from '@core/middleware/global';
-import { IConfig } from '@config/config.types';
-import { logger } from '@shared/helpers/logger';
-import { presets as corePresets } from '@core/helpers/presets';
-import { SwaggerMiddleware } from '@core/middleware/swagger';
-import { Validator } from '@shared/helpers/validation';
+import { default as config } from '~config';
+import { ErrorMiddleware } from '~core/middleware/error';
+import { GlobalMiddleware } from '~core/middleware/global';
+import { IConfig } from '~config/config.types';
+import { logger } from '~shared/helpers/logger';
+import { presets as corePresets } from '~core/helpers/presets';
+import { SwaggerMiddleware } from '~core/middleware/swagger';
+import { Validator } from '~shared/helpers/validation';
 
-import { CoreModule } from '@core';
-import { SampleModule } from '@sample';
+import { CoreModule } from '~core';
+import { SampleModule } from '~sample';
 
 export class App {
 	public app: Application = express();

--- a/server/src/core/controllers/fallback.ts
+++ b/server/src/core/controllers/fallback.ts
@@ -1,5 +1,5 @@
-import { IRequest, IResponse, INext } from '@shared/shared.types';
-import { NotFoundError } from '@shared/helpers/error';
+import { IRequest, IResponse, INext } from '~shared/shared.types';
+import { NotFoundError } from '~shared/helpers/error';
 
 export class FallbackController {
 	// Get fallback

--- a/server/src/core/controllers/status.ts
+++ b/server/src/core/controllers/status.ts
@@ -1,7 +1,7 @@
 import { ApiPath, ApiOperationGet, SwaggerDefinitionConstant } from 'swagger-express-ts';
 
-import { IRequest, IResponse, INext } from '@shared/shared.types';
-import { version } from '@pkg';
+import { IRequest, IResponse, INext } from '~shared/shared.types';
+import { version } from '~pkg';
 
 import { IStatus } from '../core.types';
 

--- a/server/src/core/core.models.ts
+++ b/server/src/core/core.models.ts
@@ -1,6 +1,6 @@
 import { SwaggerDefinitionConstant } from 'swagger-express-ts';
 
-import { ISwaggerModels } from '@shared/shared.types';
+import { ISwaggerModels } from '~shared/shared.types';
 
 export const models: ISwaggerModels = {
 	Error: {

--- a/server/src/core/helpers/presets/env.ts
+++ b/server/src/core/helpers/presets/env.ts
@@ -1,7 +1,7 @@
 import { default as Joi } from 'joi';
 
-import { allowUnknown } from '@shared/helpers/validation/options';
-import { IValidationPreset } from '@shared/shared.types';
+import { allowUnknown } from '~shared/helpers/validation/options';
+import { IValidationPreset } from '~shared/shared.types';
 
 export const env: IValidationPreset = {
 	options: allowUnknown,

--- a/server/src/core/helpers/presets/index.ts
+++ b/server/src/core/helpers/presets/index.ts
@@ -1,4 +1,4 @@
-import { IValidationPreset } from '@shared/shared.types';
+import { IValidationPreset } from '~shared/shared.types';
 
 import { env } from './env';
 

--- a/server/src/core/index.ts
+++ b/server/src/core/index.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 
-import { ISwaggerModels } from '@shared/shared.types';
+import { ISwaggerModels } from '~shared/shared.types';
 
 import { CoreRoutes } from './routes';
 import { models } from './core.models';

--- a/server/src/core/middleware/error.spec.ts
+++ b/server/src/core/middleware/error.spec.ts
@@ -1,9 +1,9 @@
 import { mockReq, mockRes } from 'sinon-express-mock';
 
-import { CustomError } from '@shared/helpers/error';
-import { IRequest, IResponse, ICustomError, IBodyError, IHeadersError, IParamsError, IQueryError } from '@shared/shared.types';
-import { validateErrorBody } from '@test/helpers/error';
-import { ValidationError } from '@shared/helpers/validation/error';
+import { CustomError } from '~shared/helpers/error';
+import { IRequest, IResponse, ICustomError, IBodyError, IHeadersError, IParamsError, IQueryError } from '~shared/shared.types';
+import { validateErrorBody } from '~test/helpers/error';
+import { ValidationError } from '~shared/helpers/validation/error';
 
 import { ErrorMiddleware } from './error';
 

--- a/server/src/core/middleware/error.ts
+++ b/server/src/core/middleware/error.ts
@@ -1,8 +1,8 @@
 import { propOr } from 'ramda';
 
-import { CustomError, BodyError, HeadersError, ParamsError, QueryError } from '@shared/helpers/error';
-import { IRequest, IResponse, INext, ICustomError } from '@shared/shared.types';
-import { ValidationError } from '@shared/helpers/validation/error';
+import { CustomError, BodyError, HeadersError, ParamsError, QueryError } from '~shared/helpers/error';
+import { IRequest, IResponse, INext, ICustomError } from '~shared/shared.types';
+import { ValidationError } from '~shared/helpers/validation/error';
 
 export class ErrorMiddleware {
 	public static handleError(err: string | Error | ICustomError | null | undefined, req: IRequest, res: IResponse, next: INext): IResponse | void {

--- a/server/src/core/middleware/swagger.ts
+++ b/server/src/core/middleware/swagger.ts
@@ -2,9 +2,9 @@ import { Application } from 'express';
 import { express as swaggerExpress, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { serve as swaggerServe, setup as swaggerSetup } from 'swagger-ui-express';
 
-import { default as config }  from '@config';
-import { ISwaggerModels } from '@shared/shared.types';
-import { name, version } from '@pkg';
+import { default as config }  from '~config';
+import { ISwaggerModels } from '~shared/shared.types';
+import { name, version } from '~pkg';
 
 export class SwaggerMiddleware {
 	public static load(app: Application, models: ISwaggerModels): void {

--- a/server/src/sample/v1/controllers/sample.ts
+++ b/server/src/sample/v1/controllers/sample.ts
@@ -1,7 +1,7 @@
 import { ApiPath, ApiOperationGet, ApiOperationPost, SwaggerDefinitionConstant } from 'swagger-express-ts';
 
-import { IRequest, IResponse, INext } from '@shared/shared.types';
-import { NotFoundError, ConflictError } from '@shared/helpers/error';
+import { IRequest, IResponse, INext } from '~shared/shared.types';
+import { NotFoundError, ConflictError } from '~shared/helpers/error';
 
 import { ISample } from '../sample.types';
 

--- a/server/src/sample/v1/helpers/presets/index.ts
+++ b/server/src/sample/v1/helpers/presets/index.ts
@@ -1,4 +1,4 @@
-import { IValidationPreset } from '@shared/shared.types';
+import { IValidationPreset } from '~shared/shared.types';
 
 import { sample } from './sample';
 

--- a/server/src/sample/v1/helpers/presets/sample.ts
+++ b/server/src/sample/v1/helpers/presets/sample.ts
@@ -1,7 +1,7 @@
 import { default as Joi } from 'joi';
 
-import { allowUnknown } from '@shared/helpers/validation/options';
-import { IValidationPreset } from '@shared/shared.types';
+import { allowUnknown } from '~shared/helpers/validation/options';
+import { IValidationPreset } from '~shared/shared.types';
 
 export const sample: IValidationPreset = {
 	options: allowUnknown,

--- a/server/src/sample/v1/index.ts
+++ b/server/src/sample/v1/index.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 
-import { ISwaggerModels } from '@shared/shared.types';
+import { ISwaggerModels } from '~shared/shared.types';
 
 import { models } from './sample.models';
 import { SampleRoutes } from './routes';

--- a/server/src/sample/v1/routes.ts
+++ b/server/src/sample/v1/routes.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 
-import { DataMiddleware } from '@shared/middleware/data';
+import { DataMiddleware } from '~shared/middleware/data';
 
 import { presets } from './helpers/presets';
 import { SampleController } from './controllers/sample';

--- a/server/src/sample/v1/sample.models.ts
+++ b/server/src/sample/v1/sample.models.ts
@@ -1,6 +1,6 @@
 import { SwaggerDefinitionConstant } from 'swagger-express-ts';
 
-import { ISwaggerModels } from '@shared/shared.types';
+import { ISwaggerModels } from '~shared/shared.types';
 
 export const models: ISwaggerModels = {
 	Sample: {

--- a/server/src/shared/helpers/error.spec.ts
+++ b/server/src/shared/helpers/error.spec.ts
@@ -1,6 +1,6 @@
 import { ValidationError as JoiValidationError } from 'joi';
 
-import { validateError } from '@test/helpers/error';
+import { validateError } from '~test/helpers/error';
 
 import {
 	CustomError,

--- a/server/src/shared/helpers/error.ts
+++ b/server/src/shared/helpers/error.ts
@@ -2,7 +2,7 @@ import { default as uuid } from 'uuid';
 import { pathOr } from 'ramda';
 import { ValidationErrorItem } from 'joi';
 
-import { default as config } from '@config';
+import { default as config } from '~config';
 
 import { ICustomError, ICustomErrorDetail, IValidationError } from '../shared.types';
 

--- a/server/src/shared/helpers/logger.ts
+++ b/server/src/shared/helpers/logger.ts
@@ -1,6 +1,6 @@
 // Temporary require statement: @studiohyperdrive/logger should export an ESModule bundle for Node.js
 const Logger = require('@studiohyperdrive/logger'); // tslint:disable-line variable-name
 
-import { default as config } from '@config';
+import { default as config } from '~config';
 
 export const logger = new Logger(config.logger);

--- a/server/test/helpers/error.ts
+++ b/server/test/helpers/error.ts
@@ -1,5 +1,5 @@
-import { ICustomError, ICustomErrorDetail } from '@shared/shared.types';
-import { default as config } from '@config';
+import { ICustomError, ICustomErrorDetail } from '~shared/shared.types';
+import { default as config } from '~config';
 
 export const validateError = <T>(err: ICustomError, type: T, status: number, name: string, message: string, details?: ICustomErrorDetail[]): void => {
 	expect(err).toBeDefined();

--- a/server/test/integration/core/docs.spec.ts
+++ b/server/test/integration/core/docs.spec.ts
@@ -1,6 +1,6 @@
 import { default as supertest } from 'supertest';
 
-import { App, CONFIG } from '@app';
+import { App, CONFIG } from '~app';
 
 import { validateErrorBody } from '../../helpers/error';
 

--- a/server/test/integration/core/fallback.spec.ts
+++ b/server/test/integration/core/fallback.spec.ts
@@ -1,6 +1,6 @@
 import { default as supertest } from 'supertest';
 
-import { App } from '@app';
+import { App } from '~app';
 
 import { validateErrorBody } from '../../helpers/error';
 

--- a/server/test/integration/core/status.spec.ts
+++ b/server/test/integration/core/status.spec.ts
@@ -1,7 +1,7 @@
 import { default as supertest } from 'supertest';
 
-import { App } from '@app';
-import { version } from '@pkg';
+import { App } from '~app';
+import { version } from '~pkg';
 
 const api = supertest(new App(false).app);
 

--- a/server/test/integration/sample/sample.spec.ts
+++ b/server/test/integration/sample/sample.spec.ts
@@ -1,6 +1,6 @@
 import { default as supertest } from 'supertest';
 
-import { App } from '@app';
+import { App } from '~app';
 
 import { validateErrorBody } from '../../helpers/error';
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -29,20 +29,20 @@
 			"node_modules/@types"
 		],
 		"paths": {
-			"@app": ["src/app"],
-			"@config": ["src/config"],
-			"@config/*": ["src/config/*"],
-			"@core": ["src/core"],
-			"@core/*": ["src/core/*"],
-			"@mocks": ["test/mocks"],
-			"@mocks/*": ["test/mocks/*"],
-			"@pkg": ["package.json"],
-			"@sample": ["src/sample"],
-			"@sample/*": ["src/sample/*"],
-			"@shared": ["src/shared"],
-			"@shared/*": ["src/shared/*"],
-			"@test": ["test"],
-			"@test/*": ["test/*"]
+			"~app": ["src/app"],
+			"~config": ["src/config"],
+			"~config/*": ["src/config/*"],
+			"~core": ["src/core"],
+			"~core/*": ["src/core/*"],
+			"~mocks": ["test/mocks"],
+			"~mocks/*": ["test/mocks/*"],
+			"~pkg": ["package.json"],
+			"~sample": ["src/sample"],
+			"~sample/*": ["src/sample/*"],
+			"~shared": ["src/shared"],
+			"~shared/*": ["src/shared/*"],
+			"~test": ["test"],
+			"~test/*": ["test/*"]
 		}
 	},
 	"include": [


### PR DESCRIPTION
Should fix conflicts with (private) scoped npm packages.

@bertyhell Should fix #75 :)