### PR TITLE
fix(env): mention env var name when throwing env related errors

### DIFF
--- a/server/src/config/helpers/env.spec.ts
+++ b/server/src/config/helpers/env.spec.ts
@@ -5,7 +5,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to a boolean (true)', (done: jest.DoneCallback) => {
 			process.env.CONVERT = 'true';
 
-			const result: boolean = EnvHelper.envToBoolean(process.env.CONVERT);
+			const result: boolean = EnvHelper.envToBoolean('CONVERT');
 
 			expect(result).toBeTrue();
 			done();
@@ -14,7 +14,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to a boolean (false)', (done: jest.DoneCallback) => {
 			process.env.CONVERT = 'false';
 
-			const result: boolean = EnvHelper.envToBoolean(process.env.CONVERT);
+			const result: boolean = EnvHelper.envToBoolean('CONVERT');
 
 			expect(result).toBeFalse();
 			done();
@@ -22,8 +22,8 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 
 		it('Should throw an error when the environment variable is not defined', (done: jest.DoneCallback) => {
 			expect(() => {
-				EnvHelper.envToBoolean(process.env.CONVERT_UNDEFINED);
-			}).toThrowError('Environment variable is not defined');
+				EnvHelper.envToBoolean('CONVERT_UNDEFINED');
+			}).toThrowError('Environment variable CONVERT_UNDEFINED is not defined');
 			done();
 		});
 	});
@@ -32,7 +32,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to a number', (done: jest.DoneCallback) => {
 			process.env.CONVERT = '1';
 
-			const result: number = EnvHelper.envToNumber(process.env.CONVERT);
+			const result: number = EnvHelper.envToNumber('CONVERT');
 
 			expect(result).toBeNumber();
 			expect(result).toEqual(1);
@@ -42,7 +42,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to a number', (done: jest.DoneCallback) => {
 			process.env.CONVERT = 'invalid';
 
-			const result: number = EnvHelper.envToNumber(process.env.CONVERT);
+			const result: number = EnvHelper.envToNumber('CONVERT');
 
 			expect(result).toBeNaN();
 			done();
@@ -50,8 +50,8 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 
 		it('Should throw an error when the environment variable is not defined', (done: jest.DoneCallback) => {
 			expect(() => {
-				EnvHelper.envToNumber(process.env.CONVERT_UNDEFINED);
-			}).toThrowError('Environment variable is not defined');
+				EnvHelper.envToNumber('CONVERT_UNDEFINED');
+			}).toThrowError('Environment variable CONVERT_UNDEFINED is not defined');
 			done();
 		});
 	});
@@ -60,7 +60,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to an array', (done: jest.DoneCallback) => {
 			process.env.CONVERT = 'one,two,three';
 
-			const result: string[] = EnvHelper.envToArray(process.env.CONVERT);
+			const result: string[] = EnvHelper.envToArray('CONVERT');
 
 			expect(result).toBeArrayOfSize(3);
 			expect(result).toEqual(['one', 'two', 'three']);
@@ -70,7 +70,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to an array (custom separator)', (done: jest.DoneCallback) => {
 			process.env.CONVERT = 'one;two;three';
 
-			const result: string[] = EnvHelper.envToArray(process.env.CONVERT, ';');
+			const result: string[] = EnvHelper.envToArray('CONVERT', ';');
 
 			expect(result).toBeArrayOfSize(3);
 			expect(result).toEqual(['one', 'two', 'three']);
@@ -79,8 +79,8 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 
 		it('Should throw an error when the environment variable is not defined', (done: jest.DoneCallback) => {
 			expect(() => {
-				EnvHelper.envToArray(process.env.CONVERT_UNDEFINED);
-			}).toThrowError('Environment variable is not defined');
+				EnvHelper.envToArray('CONVERT_UNDEFINED');
+			}).toThrowError('Environment variable CONVERT_UNDEFINED is not defined');
 			done();
 		});
 	});
@@ -89,7 +89,7 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 		it('Should convert an environment variable to an object', (done: jest.DoneCallback) => {
 			process.env.CONVERT = JSON.stringify({ key: 'value' });
 
-			const result: object = EnvHelper.envToObject(process.env.CONVERT);
+			const result: object = EnvHelper.envToObject('CONVERT');
 
 			expect(result).toBeObject();
 			expect(result).toEqual({
@@ -102,15 +102,15 @@ describe('[UNIT - CONFIG] EnvHelper', () => {
 			process.env.CONVERT = 'invalid';
 
 			expect(() => {
-				EnvHelper.envToObject(process.env.CONVERT);
-			}).toThrowError('Environment variable is not a valid JSON string');
+				EnvHelper.envToObject('CONVERT');
+			}).toThrowError('Environment variable CONVERT is not a valid JSON string');
 			done();
 		});
 
 		it('Should throw an error when the environment variable is not defined', (done: jest.DoneCallback) => {
 			expect(() => {
-				EnvHelper.envToObject(process.env.CONVERT_UNDEFINED);
-			}).toThrowError('Environment variable is not defined');
+				EnvHelper.envToObject('CONVERT_UNDEFINED');
+			}).toThrowError('Environment variable CONVERT_UNDEFINED is not defined');
 			done();
 		});
 	});

--- a/server/src/config/helpers/env.ts
+++ b/server/src/config/helpers/env.ts
@@ -1,40 +1,40 @@
 import { isNil } from 'ramda';
 
 export class EnvHelper {
-	public static envToBoolean(env: string = ''): boolean {
-		this.checkEmpty(env);
+	public static envToBoolean(envVar: string = ''): boolean {
+		this.checkEmpty(envVar);
 
-		return env === 'true';
+		return process.env[envVar] === 'true';
 	}
 
-	public static envToNumber(env: string = ''): number {
-		this.checkEmpty(env);
+	public static envToNumber(envVar: string = ''): number {
+		this.checkEmpty(envVar);
 
-		return parseInt(env, 10);
+		return parseInt(process.env[envVar], 10);
 	}
 
-	public static envToArray(env: string = '', separator: string = ','): string[] {
-		this.checkEmpty(env);
+	public static envToArray(envVar: string = '', separator: string = ','): string[] {
+		this.checkEmpty(envVar);
 
-		return env.split(separator);
+		return process.env[envVar].split(separator);
 	}
 
-	public static envToObject(env: string = ''): object {
-		this.checkEmpty(env);
+	public static envToObject(envVar: string = ''): object {
+		this.checkEmpty(envVar);
 
 		let obj: object;
 		try {
-			obj = JSON.parse(env);
+			obj = JSON.parse(process.env[envVar]);
 		} catch {
-			throw new Error('Environment variable is not a valid JSON string');
+			throw new Error(`Environment variable ${envVar} is not a valid JSON string`);
 		}
 
 		return obj;
 	}
 
-	private static checkEmpty(env: string): void {
-		if (isNil(env) || env === '') {
-			throw new Error('Environment variable is not defined');
+	private static checkEmpty(envVar: string): void {
+		if (isNil(process.env[envVar]) || process.env[envVar] === '') {
+			throw new Error(`Environment variable ${envVar} is not defined`);
 		}
 	}
 }

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,18 +1,18 @@
-import { IConfig, LoggerPresets } from './config.types';
+import { IConfig } from './config.types';
 import { EnvHelper } from './helpers/env';
 import { default as loggerPresets } from './presets/logger';
 
 export default {
 	state: {
 		env: process.env.NODE_ENV,
-		docs: EnvHelper.envToBoolean(process.env.STATE_DOCS),
-		production: EnvHelper.envToBoolean(process.env.STATE_PRODUCTION),
-		test: EnvHelper.envToBoolean(process.env.STATE_TEST),
+		docs: EnvHelper.envToBoolean('STATE_DOCS'),
+		production: EnvHelper.envToBoolean('STATE_PRODUCTION'),
+		test: EnvHelper.envToBoolean('STATE_TEST'),
 	},
 	server: {
-		host: process.env.HOST,
-		port: EnvHelper.envToNumber(process.env.PORT),
+		host: 'HOST',
+		port: EnvHelper.envToNumber('PORT'),
 		timezone: process.env.TZ,
 	},
-	logger: loggerPresets[process.env['LOGGING_PRESET']],
+	logger: loggerPresets[process.env.LOGGING_PRESET],
 } as IConfig;

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -10,7 +10,7 @@ export default {
 		test: EnvHelper.envToBoolean('STATE_TEST'),
 	},
 	server: {
-		host: 'HOST',
+		host: process.env.HOST,
 		port: EnvHelper.envToNumber('PORT'),
 		timezone: process.env.TZ,
 	},


### PR DESCRIPTION
Currently the error message looks like this:
```
Error: Environment variable is not defined
```

After this PR it will look like this:
```
Error: Environment variable CONVERT is not defined
```